### PR TITLE
Version 2.2.0

### DIFF
--- a/Litdex.Security.RNG.csproj
+++ b/Litdex.Security.RNG.csproj
@@ -5,20 +5,16 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Shiroechi</Authors>
     <Company>Litdex</Company>
-    <Description></Description>
+    <Description>A module containing the RNG set.</Description>
     <RepositoryType>git</RepositoryType>
     <PackageProjectUrl>https://github.com/Shiroechi/Litdex.Security.RNG</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Shiroechi/Litdex.Security.RNG</RepositoryUrl>
     <PackageTags>Random RNG PRNG</PackageTags>
     <NeutralLanguage>English</NeutralLanguage>
-    <Version>2.1.0</Version>
+    <Version>2.1.1</Version>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
     <RootNamespace>Litdex</RootNamespace>
-    <PackageReleaseNotes>Add new RNG algorithm
-- GJrand
-- Tyche
-- Romu 
-</PackageReleaseNotes>
+    <PackageReleaseNotes>Add missing namespace in Romu random.</PackageReleaseNotes>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/Litdex.Security.RNG.csproj
+++ b/Litdex.Security.RNG.csproj
@@ -11,14 +11,38 @@
     <RepositoryUrl>https://github.com/Shiroechi/Litdex.Security.RNG</RepositoryUrl>
     <PackageTags>Random RNG PRNG</PackageTags>
     <NeutralLanguage>English</NeutralLanguage>
-    <Version>2.1.1</Version>
+    <Version>2.2.0</Version>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
     <RootNamespace>Litdex</RootNamespace>
-    <PackageReleaseNotes>Add missing namespace in Romu random.</PackageReleaseNotes>
+    <PackageReleaseNotes>- Add missing namespace in Romu random.
+- Implement bew verion of squares RNG
+- Improve perfomace to generate UInt64(ulong) for random32
+- Improve perfomance for generatring byte array
+- New method, Shuffle.
+- New method, Sample.
+- Fix some issues.</PackageReleaseNotes>
+    <Copyright>Shiroechi</Copyright>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisLevel>latest</AnalysisLevel>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DocumentationFile>D:\Project\C#\Litdex\Litdex.Security.RNG\Litdex.Security.RNG.xml</DocumentationFile>
+    <DebugType>none</DebugType>
+    <DebugSymbols>false</DebugSymbols>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <Optimize>true</Optimize>
+    <DocumentationFile>D:\Project\C#\Litdex\Litdex.Security.RNG\Litdex.Security.RNG.xml</DocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="LICENSE">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
+  </ItemGroup>
 
 </Project>

--- a/Litdex.Security.RNG.xml
+++ b/Litdex.Security.RNG.xml
@@ -161,8 +161,11 @@
             <returns>
             Random element from the given sets.
             </returns>
+            <exception cref="T:System.ArgumentNullException">
+            	The items is null, empty or not initialized. 
+            </exception>
             <exception cref="T:System.ArgumentOutOfRangeException">
-            The items length or size can't be greater than int.MaxValue.
+            	The items length or size can't be greater than int.MaxValue.
             </exception>
         </member>
         <member name="M:Litdex.Security.RNG.IRNG.Choice``1(``0[],System.Int32)">
@@ -181,6 +184,9 @@
             <returns>
             Multiple random elements from the given sets.
             </returns>
+            <exception cref="T:System.ArgumentNullException">
+            	The items is null, empty or not initialized. 
+            </exception>
             <exception cref="T:System.ArgumentOutOfRangeException">
             <list type="bullet">
             	<item>
@@ -205,8 +211,11 @@
             <returns>
             Random element from the given sets.
             </returns>
+            <exception cref="T:System.ArgumentNullException">
+            	The items is null, empty or not initialized. 
+            </exception>
             <exception cref="T:System.ArgumentOutOfRangeException">
-            The items length or size can't be greater than int.MaxValue.
+            	The items length or size can't be greater than int.MaxValue.
             </exception>
         </member>
         <member name="M:Litdex.Security.RNG.IRNG.Choice``1(System.Collections.Generic.IList{``0},System.Int32)">
@@ -225,6 +234,9 @@
             <returns>
             Multiple random elements from the given sets.
             </returns>
+            <exception cref="T:System.ArgumentNullException">
+            	The items is null, empty or not initialized. 
+            </exception>
             <exception cref="T:System.ArgumentOutOfRangeException">
             <list type="bullet">
             	<item>
@@ -234,6 +246,103 @@
             	The number of elements to be retrieved exceeds the items size.
             	</item>
             </list>
+            </exception>
+        </member>
+        <member name="M:Litdex.Security.RNG.IRNG.Sample``1(``0[],System.Int32)">
+            <summary>
+            Select abritary distinct element randomly.
+            </summary>
+            <typeparam name="T">
+            Data type
+            </typeparam>
+            <param name="items">
+            Set of items to choose.
+            </param>
+            <param name="k">
+            The desired amount to select.
+            </param>
+            <returns>
+            Multiple random elements from the given sets.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+            	The items is null, empty or not initialized. 
+            </exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+            <list type="bullet">
+            	<item>
+            	The number of elements to be retrieved is negative or less than 1.
+            	</item>
+            	<item>
+            	The number of elements to be retrieved exceeds the items size.
+            	</item>
+            </list>
+            </exception>
+        </member>
+        <member name="M:Litdex.Security.RNG.IRNG.SampleAsync``1(``0[],System.Int32)">
+            <summary>
+            Select abritary distinct element randomly.
+            </summary>
+            <remarks>
+            Used for large data, objects or arrays.
+            </remarks>
+            <typeparam name="T">
+            Data type
+            </typeparam>
+            <param name="items">
+            Set of items to choose.
+            </param>
+            <param name="k">
+            The desired amount to select.
+            </param>
+            <returns>
+            Multiple random elements from the given sets.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+            	The items is null, empty or not initialized. 
+            </exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+            <list type="bullet">
+            	<item>
+            	The number of elements to be retrieved is negative or less than 1.
+            	</item>
+            	<item>
+            	The number of elements to be retrieved exceeds the items size.
+            	</item>
+            </list>
+            </exception>
+        </member>
+        <member name="M:Litdex.Security.RNG.IRNG.Shuffle``1(``0[])">
+            <summary>
+            Shuffle items with Fisher-Yates shuffle.
+            </summary>
+            <typeparam name="T">
+            Data type
+            </typeparam>
+            <param name="items">
+            Set of items to shuffle.
+            </param>
+            <exception cref="T:System.ArgumentNullException">
+            	The items is null, empty or not initialized. 
+            </exception>
+        </member>
+        <member name="M:Litdex.Security.RNG.IRNG.ShuffleAsync``1(``0[])">
+            <summary>
+            Shuffle items with Fisher-Yates shuffle.
+            </summary>
+            <remarks>
+            Used for large data, objects or arrays.
+            </remarks>
+            <typeparam name="T">
+            Data type
+            </typeparam>
+            <param name="items">
+            Set of items to shuffle.
+            </param>
+            <returns>
+            Shuffled items.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">
+            	The items is null, empty or not initialized. 
             </exception>
         </member>
         <member name="T:Litdex.Security.RNG.PRNG.GJrand64">
@@ -399,6 +508,251 @@
         <member name="M:Litdex.Security.RNG.PRNG.PCG32.Reseed">
             <inheritdoc/>
         </member>
+        <member name="T:Litdex.Security.RNG.PRNG.RomuDuo">
+            <summary>
+            Might be faster than RomuTrio due to using fewer registers, but might struggle with massive jobs.
+            Est. capacity = 2^61 bytes. Register pressure = 5. State size = 128 bits.
+            </summary>
+        </member>
+        <member name="M:Litdex.Security.RNG.PRNG.RomuDuo.#ctor(System.UInt64[])">
+            <summary>
+            
+            </summary>
+            <param name="seed"></param>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+            Seed need 2 numbers.
+            </exception>
+        </member>
+        <member name="M:Litdex.Security.RNG.PRNG.RomuDuo.Next">
+            <inheritdoc/>
+        </member>
+        <member name="M:Litdex.Security.RNG.PRNG.RomuDuo.AlgorithmName">
+            <inheritdoc/>
+        </member>
+        <member name="M:Litdex.Security.RNG.PRNG.RomuDuo.Reseed">
+            <inheritdoc/>
+        </member>
+        <member name="T:Litdex.Security.RNG.PRNG.RomuDuoJr">
+            <summary>
+            The fastest generator using 64-bit arith., but not suited for huge jobs.
+            Est. capacity = 2^51 bytes. Register pressure = 4. State size = 128 bits.
+            </summary>
+        </member>
+        <member name="M:Litdex.Security.RNG.PRNG.RomuDuoJr.#ctor(System.UInt64[])">
+            <summary>
+            
+            </summary>
+            <param name="seed"></param>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+            Seed need 2 numbers.
+            </exception>
+        </member>
+        <member name="M:Litdex.Security.RNG.PRNG.RomuDuoJr.Next">
+            <inheritdoc/>
+        </member>
+        <member name="M:Litdex.Security.RNG.PRNG.RomuDuoJr.AlgorithmName">
+            <inheritdoc/>
+        </member>
+        <member name="M:Litdex.Security.RNG.PRNG.RomuDuoJr.Reseed">
+            <inheritdoc/>
+        </member>
+        <member name="T:Litdex.Security.RNG.PRNG.RomuMono32">
+            <summary>
+            32-bit arithmetic: Suitable only up to 2^26 output-values. Outputs 16-bit numbers.
+            Fixed period of (2^32)-47. Must be seeded using the romuMono32_init function.
+            Capacity = 2^27 bytes. Register pressure = 2. State size = 32 bits.
+            </summary>
+        </member>
+        <member name="M:Litdex.Security.RNG.PRNG.RomuMono32.Next">
+            <inheritdoc/>
+        </member>
+        <member name="M:Litdex.Security.RNG.PRNG.RomuMono32.AlgorithmName">
+            <inheritdoc/>
+        </member>
+        <member name="M:Litdex.Security.RNG.PRNG.RomuMono32.Reseed">
+            <inheritdoc/>
+        </member>
+        <member name="T:Litdex.Security.RNG.PRNG.RomuQuad">
+            <summary>
+            More robust than anyone could need, but uses more registers than RomuTrio.
+            Est. capacity >= 2^90 bytes. Register pressure = 8 (high). State size = 256 bits.
+            </summary>
+        </member>
+        <member name="M:Litdex.Security.RNG.PRNG.RomuQuad.#ctor(System.UInt32,System.UInt32,System.UInt32,System.UInt32)">
+            <summary>
+            Create <see cref="T:Litdex.Security.RNG.PRNG.RomuQuad32"/> instance.
+            </summary>
+            <param name="seed1">
+            W state.
+            </param>
+            <param name="seed2">
+            X state.
+            </param>
+            <param name="seed3">
+            Y state.
+            </param>
+            <param name="seed4">
+            Z state.
+            </param>
+        </member>
+        <member name="M:Litdex.Security.RNG.PRNG.RomuQuad.#ctor(System.UInt32[])">
+            <summary>
+            Create <see cref="T:Litdex.Security.RNG.PRNG.RomuQuad"/> instance.
+            </summary>
+            <param name="seed">
+            A array of seed numbers.
+            </param>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+            Seed need 4 numbers.
+            </exception>
+        </member>
+        <member name="M:Litdex.Security.RNG.PRNG.RomuQuad.Finalize">
+            <summary>
+            Clear all seed.
+            </summary>
+        </member>
+        <member name="M:Litdex.Security.RNG.PRNG.RomuQuad.Next">
+            <inheritdoc/>
+        </member>
+        <member name="M:Litdex.Security.RNG.PRNG.RomuQuad.AlgorithmName">
+            <inheritdoc/>
+        </member>
+        <member name="M:Litdex.Security.RNG.PRNG.RomuQuad.Reseed">
+            <inheritdoc/>
+        </member>
+        <member name="T:Litdex.Security.RNG.PRNG.RomuQuad32">
+            <summary>
+            32-bit arithmetic: Good for general purpose use.
+            Est. capacity >= 2^62 bytes. Register pressure = 7. State size = 128 bits.
+            </summary>
+        </member>
+        <member name="M:Litdex.Security.RNG.PRNG.RomuQuad32.#ctor(System.UInt32,System.UInt32,System.UInt32,System.UInt32)">
+            <summary>
+            Create <see cref="T:Litdex.Security.RNG.PRNG.RomuQuad32"/> instance.
+            </summary>
+            <param name="seed1">
+            W state.
+            </param>
+            <param name="seed2">
+            X state.
+            </param>
+            <param name="seed3">
+            Y state.
+            </param>
+            <param name="seed4">
+            Z state.
+            </param>
+        </member>
+        <member name="M:Litdex.Security.RNG.PRNG.RomuQuad32.#ctor(System.UInt32[])">
+            <summary>
+            Create <see cref="T:Litdex.Security.RNG.PRNG.RomuQuad32"/> instance.
+            </summary>
+            <param name="seed">
+            A array of seed numbers.
+            </param>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+            Seed need 4 numbers.
+            </exception>
+        </member>
+        <member name="M:Litdex.Security.RNG.PRNG.RomuQuad32.Finalize">
+            <summary>
+            Clear all seed.
+            </summary>
+        </member>
+        <member name="M:Litdex.Security.RNG.PRNG.RomuQuad32.Next">
+            <inheritdoc/>
+        </member>
+        <member name="M:Litdex.Security.RNG.PRNG.RomuQuad32.AlgorithmName">
+            <inheritdoc/>
+        </member>
+        <member name="M:Litdex.Security.RNG.PRNG.RomuQuad32.Reseed">
+            <inheritdoc/>
+        </member>
+        <member name="T:Litdex.Security.RNG.PRNG.RomuTrio">
+            <summary>
+            Great for general purpose work, including huge jobs.
+            Est. capacity = 2^75 bytes. Register pressure = 6. State size = 192 bits.
+            </summary>
+        </member>
+        <member name="M:Litdex.Security.RNG.PRNG.RomuTrio.#ctor(System.UInt32,System.UInt32,System.UInt32)">
+            <summary>
+            Create <see cref="T:Litdex.Security.RNG.PRNG.RomuTrio"/> instance.
+            </summary>
+            <param name="seed1">
+            X state.
+            </param>
+            <param name="seed2">
+            Y state.
+            </param>
+            <param name="seed3">
+            Z state.
+            </param>
+        </member>
+        <member name="M:Litdex.Security.RNG.PRNG.RomuTrio.#ctor(System.UInt32[])">
+            <summary>
+            Create <see cref="T:Litdex.Security.RNG.PRNG.RomuTrio"/> instance.
+            </summary>
+            <param name="seed">
+            A array of seed numbers.
+            </param>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+            Seed need 3 numbers.
+            </exception>
+        </member>
+        <member name="M:Litdex.Security.RNG.PRNG.RomuTrio.Finalize">
+            <summary>
+            Clear all seed.
+            </summary>
+        </member>
+        <member name="M:Litdex.Security.RNG.PRNG.RomuTrio.Next">
+            <inheritdoc/>
+        </member>
+        <member name="M:Litdex.Security.RNG.PRNG.RomuTrio.AlgorithmName">
+            <inheritdoc/>
+        </member>
+        <member name="M:Litdex.Security.RNG.PRNG.RomuTrio.Reseed">
+            <inheritdoc/>
+        </member>
+        <member name="T:Litdex.Security.RNG.PRNG.RomuTrio32">
+            <summary>
+            32-bit arithmetic: Good for general purpose use, except for huge jobs.
+            Est. capacity >= 2^53 bytes. Register pressure = 5. State size = 96 bits.
+            </summary>
+        </member>
+        <member name="M:Litdex.Security.RNG.PRNG.RomuTrio32.#ctor(System.UInt32,System.UInt32,System.UInt32)">
+            <summary>
+            Create <see cref="T:Litdex.Security.RNG.PRNG.RomuTrio32"/> instance.
+            </summary>
+            <param name="seed1">
+            X state.
+            </param>
+            <param name="seed2">
+            Y state.
+            </param>
+            <param name="seed3">
+            Z state.
+            </param>
+        </member>
+        <member name="M:Litdex.Security.RNG.PRNG.RomuTrio32.#ctor(System.UInt32[])">
+            <summary>
+            Create <see cref="T:Litdex.Security.RNG.PRNG.RomuTrio32"/> instance.
+            </summary>
+            <param name="seed">
+            Rng seed.
+            </param>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+            Seed nedd 3 numbers.
+            </exception>
+        </member>
+        <member name="M:Litdex.Security.RNG.PRNG.RomuTrio32.Next">
+            <inheritdoc/>
+        </member>
+        <member name="M:Litdex.Security.RNG.PRNG.RomuTrio32.AlgorithmName">
+            <inheritdoc/>
+        </member>
+        <member name="M:Litdex.Security.RNG.PRNG.RomuTrio32.Reseed">
+            <inheritdoc/>
+        </member>
         <member name="T:Litdex.Security.RNG.PRNG.SplitMix64">
             <summary>
             SplitMix64 PRNG Algorithm.
@@ -429,8 +783,7 @@
             Counter-based RNG based on <see cref="T:Litdex.Security.RNG.PRNG.MiddleSquareWeylSequence"/>
             
             <list type="bullet">
-            	<item>https://arxiv.org/pdf/2004.06278v2.pdf</item>
-            	<item>https://arxiv.org/pdf/1704.00358v5.pdf</item>
+            	<item>https://arxiv.org/pdf/2004.06278.pdf</item>
             </list>
             </summary>
         </member>
@@ -867,251 +1220,6 @@
             non-overlapping subsequences for parallel computations.
             </summary>
         </member>
-        <member name="T:Litdex.Security.RNG.RomuDuo">
-            <summary>
-            Might be faster than RomuTrio due to using fewer registers, but might struggle with massive jobs.
-            Est. capacity = 2^61 bytes. Register pressure = 5. State size = 128 bits.
-            </summary>
-        </member>
-        <member name="M:Litdex.Security.RNG.RomuDuo.#ctor(System.UInt64[])">
-            <summary>
-            
-            </summary>
-            <param name="seed"></param>
-            <exception cref="T:System.ArgumentOutOfRangeException">
-            Seed need 2 numbers.
-            </exception>
-        </member>
-        <member name="M:Litdex.Security.RNG.RomuDuo.Next">
-            <inheritdoc/>
-        </member>
-        <member name="M:Litdex.Security.RNG.RomuDuo.AlgorithmName">
-            <inheritdoc/>
-        </member>
-        <member name="M:Litdex.Security.RNG.RomuDuo.Reseed">
-            <inheritdoc/>
-        </member>
-        <member name="T:Litdex.Security.RNG.RomuDuoJr">
-            <summary>
-            The fastest generator using 64-bit arith., but not suited for huge jobs.
-            Est. capacity = 2^51 bytes. Register pressure = 4. State size = 128 bits.
-            </summary>
-        </member>
-        <member name="M:Litdex.Security.RNG.RomuDuoJr.#ctor(System.UInt64[])">
-            <summary>
-            
-            </summary>
-            <param name="seed"></param>
-            <exception cref="T:System.ArgumentOutOfRangeException">
-            Seed need 2 numbers.
-            </exception>
-        </member>
-        <member name="M:Litdex.Security.RNG.RomuDuoJr.Next">
-            <inheritdoc/>
-        </member>
-        <member name="M:Litdex.Security.RNG.RomuDuoJr.AlgorithmName">
-            <inheritdoc/>
-        </member>
-        <member name="M:Litdex.Security.RNG.RomuDuoJr.Reseed">
-            <inheritdoc/>
-        </member>
-        <member name="T:Litdex.Security.RNG.RomuMono32">
-            <summary>
-            32-bit arithmetic: Suitable only up to 2^26 output-values. Outputs 16-bit numbers.
-            Fixed period of (2^32)-47. Must be seeded using the romuMono32_init function.
-            Capacity = 2^27 bytes. Register pressure = 2. State size = 32 bits.
-            </summary>
-        </member>
-        <member name="M:Litdex.Security.RNG.RomuMono32.Next">
-            <inheritdoc/>
-        </member>
-        <member name="M:Litdex.Security.RNG.RomuMono32.AlgorithmName">
-            <inheritdoc/>
-        </member>
-        <member name="M:Litdex.Security.RNG.RomuMono32.Reseed">
-            <inheritdoc/>
-        </member>
-        <member name="T:Litdex.Security.RNG.RomuQuad">
-            <summary>
-            More robust than anyone could need, but uses more registers than RomuTrio.
-            Est. capacity >= 2^90 bytes. Register pressure = 8 (high). State size = 256 bits.
-            </summary>
-        </member>
-        <member name="M:Litdex.Security.RNG.RomuQuad.#ctor(System.UInt32,System.UInt32,System.UInt32,System.UInt32)">
-            <summary>
-            Create <see cref="T:Litdex.Security.RNG.RomuQuad32"/> instance.
-            </summary>
-            <param name="seed1">
-            W state.
-            </param>
-            <param name="seed2">
-            X state.
-            </param>
-            <param name="seed3">
-            Y state.
-            </param>
-            <param name="seed4">
-            Z state.
-            </param>
-        </member>
-        <member name="M:Litdex.Security.RNG.RomuQuad.#ctor(System.UInt32[])">
-            <summary>
-            Create <see cref="T:Litdex.Security.RNG.RomuQuad"/> instance.
-            </summary>
-            <param name="seed">
-            A array of seed numbers.
-            </param>
-            <exception cref="T:System.ArgumentOutOfRangeException">
-            Seed need 4 numbers.
-            </exception>
-        </member>
-        <member name="M:Litdex.Security.RNG.RomuQuad.Finalize">
-            <summary>
-            Clear all seed.
-            </summary>
-        </member>
-        <member name="M:Litdex.Security.RNG.RomuQuad.Next">
-            <inheritdoc/>
-        </member>
-        <member name="M:Litdex.Security.RNG.RomuQuad.AlgorithmName">
-            <inheritdoc/>
-        </member>
-        <member name="M:Litdex.Security.RNG.RomuQuad.Reseed">
-            <inheritdoc/>
-        </member>
-        <member name="T:Litdex.Security.RNG.RomuQuad32">
-            <summary>
-            32-bit arithmetic: Good for general purpose use.
-            Est. capacity >= 2^62 bytes. Register pressure = 7. State size = 128 bits.
-            </summary>
-        </member>
-        <member name="M:Litdex.Security.RNG.RomuQuad32.#ctor(System.UInt32,System.UInt32,System.UInt32,System.UInt32)">
-            <summary>
-            Create <see cref="T:Litdex.Security.RNG.RomuQuad32"/> instance.
-            </summary>
-            <param name="seed1">
-            W state.
-            </param>
-            <param name="seed2">
-            X state.
-            </param>
-            <param name="seed3">
-            Y state.
-            </param>
-            <param name="seed4">
-            Z state.
-            </param>
-        </member>
-        <member name="M:Litdex.Security.RNG.RomuQuad32.#ctor(System.UInt32[])">
-            <summary>
-            Create <see cref="T:Litdex.Security.RNG.RomuQuad32"/> instance.
-            </summary>
-            <param name="seed">
-            A array of seed numbers.
-            </param>
-            <exception cref="T:System.ArgumentOutOfRangeException">
-            Seed need 4 numbers.
-            </exception>
-        </member>
-        <member name="M:Litdex.Security.RNG.RomuQuad32.Finalize">
-            <summary>
-            Clear all seed.
-            </summary>
-        </member>
-        <member name="M:Litdex.Security.RNG.RomuQuad32.Next">
-            <inheritdoc/>
-        </member>
-        <member name="M:Litdex.Security.RNG.RomuQuad32.AlgorithmName">
-            <inheritdoc/>
-        </member>
-        <member name="M:Litdex.Security.RNG.RomuQuad32.Reseed">
-            <inheritdoc/>
-        </member>
-        <member name="T:Litdex.Security.RNG.RomuTrio">
-            <summary>
-            Great for general purpose work, including huge jobs.
-            Est. capacity = 2^75 bytes. Register pressure = 6. State size = 192 bits.
-            </summary>
-        </member>
-        <member name="M:Litdex.Security.RNG.RomuTrio.#ctor(System.UInt32,System.UInt32,System.UInt32)">
-            <summary>
-            Create <see cref="T:Litdex.Security.RNG.RomuTrio"/> instance.
-            </summary>
-            <param name="seed1">
-            X state.
-            </param>
-            <param name="seed2">
-            Y state.
-            </param>
-            <param name="seed3">
-            Z state.
-            </param>
-        </member>
-        <member name="M:Litdex.Security.RNG.RomuTrio.#ctor(System.UInt32[])">
-            <summary>
-            Create <see cref="T:Litdex.Security.RNG.RomuTrio"/> instance.
-            </summary>
-            <param name="seed">
-            A array of seed numbers.
-            </param>
-            <exception cref="T:System.ArgumentOutOfRangeException">
-            Seed need 3 numbers.
-            </exception>
-        </member>
-        <member name="M:Litdex.Security.RNG.RomuTrio.Finalize">
-            <summary>
-            Clear all seed.
-            </summary>
-        </member>
-        <member name="M:Litdex.Security.RNG.RomuTrio.Next">
-            <inheritdoc/>
-        </member>
-        <member name="M:Litdex.Security.RNG.RomuTrio.AlgorithmName">
-            <inheritdoc/>
-        </member>
-        <member name="M:Litdex.Security.RNG.RomuTrio.Reseed">
-            <inheritdoc/>
-        </member>
-        <member name="T:Litdex.Security.RNG.RomuTrio32">
-            <summary>
-            32-bit arithmetic: Good for general purpose use, except for huge jobs.
-            Est. capacity >= 2^53 bytes. Register pressure = 5. State size = 96 bits.
-            </summary>
-        </member>
-        <member name="M:Litdex.Security.RNG.RomuTrio32.#ctor(System.UInt32,System.UInt32,System.UInt32)">
-            <summary>
-            Create <see cref="T:Litdex.Security.RNG.RomuTrio32"/> instance.
-            </summary>
-            <param name="seed1">
-            X state.
-            </param>
-            <param name="seed2">
-            Y state.
-            </param>
-            <param name="seed3">
-            Z state.
-            </param>
-        </member>
-        <member name="M:Litdex.Security.RNG.RomuTrio32.#ctor(System.UInt32[])">
-            <summary>
-            Create <see cref="T:Litdex.Security.RNG.RomuTrio32"/> instance.
-            </summary>
-            <param name="seed">
-            Rng seed.
-            </param>
-            <exception cref="T:System.ArgumentOutOfRangeException">
-            Seed nedd 3 numbers.
-            </exception>
-        </member>
-        <member name="M:Litdex.Security.RNG.RomuTrio32.Next">
-            <inheritdoc/>
-        </member>
-        <member name="M:Litdex.Security.RNG.RomuTrio32.AlgorithmName">
-            <inheritdoc/>
-        </member>
-        <member name="M:Litdex.Security.RNG.RomuTrio32.Reseed">
-            <inheritdoc/>
-        </member>
         <member name="T:Litdex.Security.RNG.Random">
             <summary>
             Base class of all random.
@@ -1141,6 +1249,30 @@
         <member name="M:Litdex.Security.RNG.Random.NextInt(System.UInt32,System.UInt32)">
             <inheritdoc/>
         </member>
+        <member name="M:Litdex.Security.RNG.Random.NextIntFast(System.UInt32,System.UInt32,System.Boolean)">
+            <summary>
+            Lemire algorithm to generate <see cref="T:System.UInt32"/> value between 
+            lower bound and upper bound from generator.
+            </summary>
+            <remarks>
+            https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/
+            </remarks>
+            <param name="lower">
+            Lower bound or expected minimum value.
+            </param>
+            <param name="upper">
+            Upper bound or ecpected maximum value.
+            </param>
+            <param name="unbias">
+            Determine using division for reduce bias.
+            </param>
+            <returns>
+            <see cref="T:System.UInt32"/> value between lower bound and upper bound.
+            </returns>
+            <exception cref="T:System.ArgumentOutOfRangeException">
+            Lower bound is greater than or equal to upper bound.
+            </exception>
+        </member>
         <member name="M:Litdex.Security.RNG.Random.NextLong">
             <inheritdoc/>
         </member>
@@ -1163,6 +1295,18 @@
             <inheritdoc/>
         </member>
         <member name="M:Litdex.Security.RNG.Random.Choice``1(System.Collections.Generic.IList{``0},System.Int32)">
+            <inheritdoc/>
+        </member>
+        <member name="M:Litdex.Security.RNG.Random.Sample``1(``0[],System.Int32)">
+            <inheritdoc/>
+        </member>
+        <member name="M:Litdex.Security.RNG.Random.SampleAsync``1(``0[],System.Int32)">
+            <inheritdoc/>
+        </member>
+        <member name="M:Litdex.Security.RNG.Random.Shuffle``1(``0[])">
+            <inheritdoc/>
+        </member>
+        <member name="M:Litdex.Security.RNG.Random.ShuffleAsync``1(``0[])">
             <inheritdoc/>
         </member>
         <member name="M:Litdex.Security.RNG.Random.ToString">

--- a/Security/RNG/IRNG.cs
+++ b/Security/RNG/IRNG.cs
@@ -159,8 +159,11 @@ namespace Litdex.Security.RNG
 		/// <returns>
 		/// Random element from the given sets.
 		/// </returns>
+		/// <exception cref="ArgumentNullException">
+		///		The items is null, empty or not initialized. 
+		/// </exception>
 		/// <exception cref="ArgumentOutOfRangeException">
-		/// The items length or size can't be greater than int.MaxValue.
+		///		The items length or size can't be greater than int.MaxValue.
 		/// </exception>
 		T Choice<T>(T[] items);
 
@@ -179,6 +182,9 @@ namespace Litdex.Security.RNG
 		/// <returns>
 		/// Multiple random elements from the given sets.
 		/// </returns>
+		/// <exception cref="ArgumentNullException">
+		///		The items is null, empty or not initialized. 
+		/// </exception>
 		/// <exception cref="ArgumentOutOfRangeException">
 		/// <list type="bullet">
 		///		<item>
@@ -203,8 +209,11 @@ namespace Litdex.Security.RNG
 		/// <returns>
 		/// Random element from the given sets.
 		/// </returns>
+		/// <exception cref="ArgumentNullException">
+		///		The items is null, empty or not initialized. 
+		/// </exception>
 		/// <exception cref="ArgumentOutOfRangeException">
-		/// The items length or size can't be greater than int.MaxValue.
+		///		The items length or size can't be greater than int.MaxValue.
 		/// </exception>
 		T Choice<T>(IList<T> items);
 
@@ -223,6 +232,9 @@ namespace Litdex.Security.RNG
 		/// <returns>
 		/// Multiple random elements from the given sets.
 		/// </returns>
+		/// <exception cref="ArgumentNullException">
+		///		The items is null, empty or not initialized. 
+		/// </exception>
 		/// <exception cref="ArgumentOutOfRangeException">
 		/// <list type="bullet">
 		///		<item>
@@ -234,5 +246,6 @@ namespace Litdex.Security.RNG
 		/// </list>
 		/// </exception>
 		T[] Choice<T>(IList<T> items, int select);
+
 	}
 }

--- a/Security/RNG/IRNG.cs
+++ b/Security/RNG/IRNG.cs
@@ -248,6 +248,36 @@ namespace Litdex.Security.RNG
 		T[] Choice<T>(IList<T> items, int select);
 
 		/// <summary>
+		/// Select abritary distinct element randomly.
+		/// </summary>
+		/// <typeparam name="T">
+		/// Data type
+		/// </typeparam>
+		/// <param name="items">
+		/// Set of items to choose.
+		/// </param>
+		/// <param name="k">
+		/// The desired amount to select.
+		/// </param>
+		/// <returns>
+		/// Multiple random elements from the given sets.
+		/// </returns>
+		/// <exception cref="ArgumentNullException">
+		///		The items is null, empty or not initialized. 
+		/// </exception>
+		/// <exception cref="ArgumentOutOfRangeException">
+		/// <list type="bullet">
+		///		<item>
+		///		The number of elements to be retrieved is negative or less than 1.
+		///		</item>
+		///		<item>
+		///		The number of elements to be retrieved exceeds the items size.
+		///		</item>
+		/// </list>
+		/// </exception>
+		T[] Sample<T>(T[] items, int k);
+
+		/// <summary>
 		/// Shuffle items with Fisher-Yates shuffle.
 		/// </summary>
 		/// <typeparam name="T">

--- a/Security/RNG/IRNG.cs
+++ b/Security/RNG/IRNG.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Litdex.Security.RNG
 {
@@ -284,6 +285,39 @@ namespace Litdex.Security.RNG
 		T[] Sample<T>(T[] items, int k);
 
 		/// <summary>
+		/// Select abritary distinct element randomly.
+		/// </summary>
+		/// <remarks>
+		/// Used for large data, objects or arrays.
+		/// </remarks>
+		/// <typeparam name="T">
+		/// Data type
+		/// </typeparam>
+		/// <param name="items">
+		/// Set of items to choose.
+		/// </param>
+		/// <param name="k">
+		/// The desired amount to select.
+		/// </param>
+		/// <returns>
+		/// Multiple random elements from the given sets.
+		/// </returns>
+		/// <exception cref="ArgumentNullException">
+		///		The items is null, empty or not initialized. 
+		/// </exception>
+		/// <exception cref="ArgumentOutOfRangeException">
+		/// <list type="bullet">
+		///		<item>
+		///		The number of elements to be retrieved is negative or less than 1.
+		///		</item>
+		///		<item>
+		///		The number of elements to be retrieved exceeds the items size.
+		///		</item>
+		/// </list>
+		/// </exception>
+		Task<T[]> SampleAsync<T>(T[] items, int k);
+
+		/// <summary>
 		/// Shuffle items with Fisher-Yates shuffle.
 		/// </summary>
 		/// <typeparam name="T">
@@ -296,6 +330,26 @@ namespace Litdex.Security.RNG
 		///		The items is null, empty or not initialized. 
 		/// </exception>
 		void Shuffle<T>(T[] items);
+
+		/// <summary>
+		/// Shuffle items with Fisher-Yates shuffle.
+		/// </summary>
+		/// <remarks>
+		/// Used for large data, objects or arrays.
+		/// </remarks>
+		/// <typeparam name="T">
+		/// Data type
+		/// </typeparam>
+		/// <param name="items">
+		/// Set of items to shuffle.
+		/// </param>
+		/// <returns>
+		/// Shuffled items.
+		/// </returns>
+		/// <exception cref="ArgumentNullException">
+		///		The items is null, empty or not initialized. 
+		/// </exception>
+		Task ShuffleAsync<T>(T[] items);
 
 		#endregion Sequence
 	}

--- a/Security/RNG/IRNG.cs
+++ b/Security/RNG/IRNG.cs
@@ -247,5 +247,18 @@ namespace Litdex.Security.RNG
 		/// </exception>
 		T[] Choice<T>(IList<T> items, int select);
 
+		/// <summary>
+		/// Shuffle items with Fisher-Yates shuffle.
+		/// </summary>
+		/// <typeparam name="T">
+		/// Data type
+		/// </typeparam>
+		/// <param name="items">
+		/// Set of items to shuffle.
+		/// </param>
+		/// <exception cref="ArgumentNullException">
+		///		The items is null, empty or not initialized. 
+		/// </exception>
+		void Shuffle<T>(T[] items);
 	}
 }

--- a/Security/RNG/IRNG.cs
+++ b/Security/RNG/IRNG.cs
@@ -21,6 +21,8 @@ namespace Litdex.Security.RNG
 		/// </summary>
 		void Reseed();
 
+		#region Basic
+
 		/// <summary>
 		/// Generate <see cref="bool"/> value from generator.
 		/// </summary>
@@ -146,6 +148,10 @@ namespace Litdex.Security.RNG
 		/// Lower bound is greater than or equal to upper bound.
 		/// </exception>
 		double NextDouble(double lower, double upper);
+
+		#endregion Basic
+
+		#region Sequence
 
 		/// <summary>
 		/// Select one element randomly.
@@ -290,5 +296,7 @@ namespace Litdex.Security.RNG
 		///		The items is null, empty or not initialized. 
 		/// </exception>
 		void Shuffle<T>(T[] items);
+
+		#endregion Sequence
 	}
 }

--- a/Security/RNG/PRNG/JSF64.cs
+++ b/Security/RNG/PRNG/JSF64.cs
@@ -37,8 +37,7 @@ namespace Litdex.Security.RNG.PRNG
 				{
 					this.Next();
 				}
-			}
-			
+			}			
 		}
 
 		/// <summary>

--- a/Security/RNG/PRNG/MiddleSquareWeylSequence.cs
+++ b/Security/RNG/PRNG/MiddleSquareWeylSequence.cs
@@ -14,9 +14,9 @@ namespace Litdex.Security.RNG.PRNG
 	{
 		#region Member
 
-		private ulong _Output = 0; //random output
-		private ulong _Sequence = 0; //Weyl sequence
-		private ulong _Increment = 0xB5AD4ECEDA1CE2A9; //odd constant
+		private ulong _Output = 0; // random output
+		private ulong _Sequence = 0; // Weyl sequence
+		private ulong _Increment = 0xB5AD4ECEDA1CE2A9; // odd constant
 
 		#endregion Member
 

--- a/Security/RNG/PRNG/PCG32.cs
+++ b/Security/RNG/PRNG/PCG32.cs
@@ -50,7 +50,7 @@ namespace Litdex.Security.RNG.PRNG
 		protected override ulong Next()
 		{
 			var oldseed = this._Seed;
-			this._Seed = oldseed * 6364136223846793005 + (this._Increment | 1);
+			this._Seed = (oldseed * 6364136223846793005) + (this._Increment | 1);
 			var xorshifted = (uint)((oldseed >> 18) ^ oldseed) >> 27;
 			var rot = (uint)(oldseed >> 59);
 			return (xorshifted >> (int)rot) | (xorshifted << (int)((-rot) & 31));

--- a/Security/RNG/PRNG/PCG32.cs
+++ b/Security/RNG/PRNG/PCG32.cs
@@ -30,8 +30,9 @@ namespace Litdex.Security.RNG.PRNG
 			}
 			else
 			{
-				this._Seed = seed;
+				this._Seed = seed + increment;
 				this._Increment = increment;
+				this.Next();
 			}
 		}
 
@@ -77,6 +78,9 @@ namespace Litdex.Security.RNG.PRNG
 				rng.GetNonZeroBytes(bytes);
 				this._Increment = BitConverter.ToUInt64(bytes, 0);
 			}
+
+			this._Seed += this._Increment;
+			this.Next();
 		}
 
 		#endregion Public Method

--- a/Security/RNG/PRNG/RomuDuo.cs
+++ b/Security/RNG/PRNG/RomuDuo.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Security.Cryptography;
 
-namespace Litdex.Security.RNG
+namespace Litdex.Security.RNG.PRNG
 {
 	/// <summary>
 	/// Might be faster than RomuTrio due to using fewer registers, but might struggle with massive jobs.

--- a/Security/RNG/PRNG/RomuDuoJr.cs
+++ b/Security/RNG/PRNG/RomuDuoJr.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Security.Cryptography;
 
-namespace Litdex.Security.RNG
+namespace Litdex.Security.RNG.PRNG
 {
 	/// <summary>
 	/// The fastest generator using 64-bit arith., but not suited for huge jobs.

--- a/Security/RNG/PRNG/RomuMono32.cs
+++ b/Security/RNG/PRNG/RomuMono32.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Security.Cryptography;
 
-namespace Litdex.Security.RNG
+namespace Litdex.Security.RNG.PRNG
 {
 	/// <summary>
 	/// 32-bit arithmetic: Suitable only up to 2^26 output-values. Outputs 16-bit numbers.

--- a/Security/RNG/PRNG/RomuQuad.cs
+++ b/Security/RNG/PRNG/RomuQuad.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Security.Cryptography;
 
-namespace Litdex.Security.RNG
+namespace Litdex.Security.RNG.PRNG
 {
 	/// <summary>
 	/// More robust than anyone could need, but uses more registers than RomuTrio.

--- a/Security/RNG/PRNG/RomuQuad.cs
+++ b/Security/RNG/PRNG/RomuQuad.cs
@@ -70,7 +70,6 @@ namespace Litdex.Security.RNG.PRNG
 			this._W = this._X = this._Y = this._Z = 0;
 		}
 
-
 		#endregion Constructor & Destructor
 
 		#region Protected Method

--- a/Security/RNG/PRNG/RomuQuad32.cs
+++ b/Security/RNG/PRNG/RomuQuad32.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Security.Cryptography;
 
-namespace Litdex.Security.RNG
+namespace Litdex.Security.RNG.PRNG
 {
 	/// <summary>
 	/// 32-bit arithmetic: Good for general purpose use.

--- a/Security/RNG/PRNG/RomuTrio.cs
+++ b/Security/RNG/PRNG/RomuTrio.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Security.Cryptography;
 
-namespace Litdex.Security.RNG
+namespace Litdex.Security.RNG.PRNG
 {
 	/// <summary>
 	/// Great for general purpose work, including huge jobs.

--- a/Security/RNG/PRNG/RomuTrio32.cs
+++ b/Security/RNG/PRNG/RomuTrio32.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Security.Cryptography;
 
-namespace Litdex.Security.RNG
+namespace Litdex.Security.RNG.PRNG
 {
 	/// <summary>
 	/// 32-bit arithmetic: Good for general purpose use, except for huge jobs.

--- a/Security/RNG/PRNG/Squares.cs
+++ b/Security/RNG/PRNG/Squares.cs
@@ -55,15 +55,15 @@ namespace Litdex.Security.RNG.PRNG
 			z = y + key;
 			
 			// round 1
-			x = x * x + y; 
+			x = (x * x) + y; 
 			x = (x >> 32) | (x << 32);
 			
 			// round 2
-			x = x * x + z; 
+			x = (x * x) + z; 
 			x = (x >> 32) | (x << 32);
 
 			// round 3
-			x = x * x + y;
+			x = (x * x) + y;
 			x = (x >> 32) | (x << 32);
 
 			// round 4

--- a/Security/RNG/PRNG/Squares.cs
+++ b/Security/RNG/PRNG/Squares.cs
@@ -7,13 +7,12 @@ namespace Litdex.Security.RNG.PRNG
 	/// Counter-based RNG based on <see cref="MiddleSquareWeylSequence"/>
 	/// 
 	/// <list type="bullet">
-	///		<item>https://arxiv.org/pdf/2004.06278v2.pdf</item>
-	///		<item>https://arxiv.org/pdf/1704.00358v5.pdf</item>
+	///		<item>https://arxiv.org/pdf/2004.06278.pdf</item>
 	/// </list>
 	/// </summary>
 	public class Squares : Random32
 	{
-		private ulong _Key = 0xc58efd154ce32f6d; //first key in key.h.
+		private ulong _Key = 0xc58efd154ce32f6d; // first key in key.h.
 		private ulong _Counter = 0;
 
 		/// <summary>
@@ -55,13 +54,20 @@ namespace Litdex.Security.RNG.PRNG
 			y = x = ctr * key; 
 			z = y + key;
 			
+			// round 1
 			x = x * x + y; 
 			x = (x >> 32) | (x << 32);
 			
+			// round 2
 			x = x * x + z; 
 			x = (x >> 32) | (x << 32);
-			
-			return (uint)((x * x + y) >> 32);
+
+			// round 3
+			x = x * x + y;
+			x = (x >> 32) | (x << 32);
+
+			// round 4
+			return (uint)((x * x) + z) >> 32;
 		}
 
 		#endregion Protected Method

--- a/Security/RNG/PRNG/Tyche.cs
+++ b/Security/RNG/PRNG/Tyche.cs
@@ -69,11 +69,11 @@ namespace Litdex.Security.RNG.PRNG
 			this._B ^= this._C;
 			this._B = this._B << 12 | this._B >> 20;
 
-			this._A += this._B ;
+			this._A += this._B;
 			this._D ^= this._A;
 			this._D = this._D << 8 | this._D >> 24;
 
-			this._C += this._D ;
+			this._C += this._D;
 			this._B ^= this._C;
 			this._B = this._B << 7 | this._B >> 25;
 		}

--- a/Security/RNG/Random.cs
+++ b/Security/RNG/Random.cs
@@ -20,6 +20,8 @@ namespace Litdex.Security.RNG
 		/// <inheritdoc/>
 		public abstract void Reseed();
 
+		#region Basic
+
 		/// <inheritdoc/>
 		public abstract bool NextBoolean();
 
@@ -145,6 +147,10 @@ namespace Litdex.Security.RNG
 			return lower + (this.NextDouble() % diff);
 		}
 
+		#endregion Basic
+
+		#region Sequence
+
 		/// <inheritdoc/>
 		public virtual T Choice<T>(T[] items)
 		{
@@ -173,8 +179,7 @@ namespace Litdex.Security.RNG
 			{
 				throw new ArgumentOutOfRangeException(nameof(select), $"The number of elements to be retrieved is negative or less than 1.");
 			}
-
-			if (select > items.Length)
+			else if (select > items.Length)
 			{
 				throw new ArgumentOutOfRangeException(nameof(select), $"The number of elements to be retrieved exceeds the items size.");
 			}
@@ -262,6 +267,8 @@ namespace Litdex.Security.RNG
 				items[index] = temp;
 			}
 		}
+
+		#endregion Sequence
 
 		/// <inheritdoc/>
 		public override string ToString()

--- a/Security/RNG/Random.cs
+++ b/Security/RNG/Random.cs
@@ -59,6 +59,57 @@ namespace Litdex.Security.RNG
 			return lower + (this.NextInt() % diff);
 		}
 
+		/// <summary>
+		/// Lemire algorithm to generate <see cref="uint"/> value between 
+		/// lower bound and upper bound from generator.
+		/// </summary>
+		/// <remarks>
+		/// https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/
+		/// </remarks>
+		/// <param name="lower">
+		/// Lower bound or expected minimum value.
+		/// </param>
+		/// <param name="upper">
+		/// Upper bound or ecpected maximum value.
+		/// </param>
+		/// <param name="unbias">
+		/// Determine using division for reduce bias.
+		/// </param>
+		/// <returns>
+		/// <see cref="uint"/> value between lower bound and upper bound.
+		/// </returns>
+		/// <exception cref="ArgumentOutOfRangeException">
+		/// Lower bound is greater than or equal to upper bound.
+		/// </exception>
+		public virtual uint NextIntFast(uint lower, uint upper, bool unbias = false)
+		{
+			if (lower >= upper)
+			{
+				throw new ArgumentOutOfRangeException(nameof(lower), "The lower bound must not be greater than or equal to the upper bound.");
+			}
+
+			uint range = (upper - lower);
+			ulong random32bit = this.NextInt();
+			ulong multiresult = random32bit * range;
+			uint leftover = (uint)multiresult;
+
+			if (unbias)
+			{
+				if (leftover < range)
+				{
+					uint threshold = (uint)((int)-range % range);
+					while (leftover < threshold)
+					{
+						random32bit = this.NextInt();
+						multiresult = random32bit * range;
+						leftover = (uint)multiresult;
+					}
+				}
+			}
+			
+			return (uint)(multiresult >> 32) + lower;
+		}
+
 		/// <inheritdoc/>
 		public abstract ulong NextLong();
 

--- a/Security/RNG/Random.cs
+++ b/Security/RNG/Random.cs
@@ -91,7 +91,7 @@ namespace Litdex.Security.RNG
 				throw new ArgumentOutOfRangeException(nameof(lower), "The lower bound must not be greater than or equal to the upper bound.");
 			}
 
-			uint range = (upper - lower);
+			uint range = upper - lower;
 			ulong random32bit = this.NextInt();
 			ulong multiresult = random32bit * range;
 			uint leftover = (uint)multiresult;

--- a/Security/RNG/Random.cs
+++ b/Security/RNG/Random.cs
@@ -207,6 +207,25 @@ namespace Litdex.Security.RNG
 		}
 
 		/// <inheritdoc/>
+		public virtual void Shuffle<T>(T[] items)
+		{
+			if (items.Length <= 0 || items == null)
+			{
+				throw new ArgumentNullException(nameof(items), $"The items is empty of null.");
+			}
+
+			T temp;
+
+			for (var i = items.Length - 1; i > 1; i--)
+			{
+				var index = this.NextLong(0, (ulong)i);
+				temp = items[i];
+				items[i] = items[index];
+				items[index] = temp;
+			}
+		}
+
+		/// <inheritdoc/>
 		public override string ToString()
 		{
 			return this.AlgorithmName();

--- a/Security/RNG/Random.cs
+++ b/Security/RNG/Random.cs
@@ -150,7 +150,7 @@ namespace Litdex.Security.RNG
 		{
 			if (items.Length <= 0 || items == null)
 			{
-				throw new ArgumentNullException(nameof(items), $"The items is empty of null.");
+				throw new ArgumentNullException(nameof(items), $"The items is empty or null.");
 			}
 
 			if (items.Length > int.MaxValue)
@@ -166,7 +166,7 @@ namespace Litdex.Security.RNG
 		{
 			if (items.Length <= 0 || items == null)
 			{
-				throw new ArgumentNullException(nameof(items), $"The items is empty of null.");
+				throw new ArgumentNullException(nameof(items), $"The items is empty or null.");
 			}
 
 			if (select < 0)
@@ -203,11 +203,53 @@ namespace Litdex.Security.RNG
 		}
 
 		/// <inheritdoc/>
+		public virtual T[] Sample<T>(T[] items, int k)
+		{
+			if (items.Length <= 0 || items == null)
+			{
+				throw new ArgumentNullException(nameof(items), $"The items is empty or null.");
+			}
+
+			if (k <= 0)
+			{
+				throw new ArgumentOutOfRangeException(nameof(k), $"The number of elements to be retrieved is negative or less than 1.");
+			}
+			else if (k > items.Length)
+			{
+				throw new ArgumentOutOfRangeException(nameof(k), $"The number of elements to be retrieved exceeds the items size.");
+			}
+
+			T[] reservoir = new T[k];
+
+			for (var i = 0; i < k; i++)
+			{
+				reservoir[i] = items[i];
+			}
+
+			if (k == items.Length)
+			{
+				return reservoir;
+			}
+
+			for (var i = k; i < items.Length; i++)
+			{
+				int index = (int)this.NextInt(0, (uint)i);
+
+				if (index < k)
+				{
+					reservoir[index] = items[i];
+				}
+			}
+
+			return reservoir;
+		}
+
+		/// <inheritdoc/>
 		public virtual void Shuffle<T>(T[] items)
 		{
 			if (items.Length <= 0 || items == null)
 			{
-				throw new ArgumentNullException(nameof(items), $"The items is empty of null.");
+				throw new ArgumentNullException(nameof(items), $"The items is empty or null.");
 			}
 
 			T temp;

--- a/Security/RNG/Random.cs
+++ b/Security/RNG/Random.cs
@@ -97,6 +97,11 @@ namespace Litdex.Security.RNG
 		/// <inheritdoc/>
 		public virtual T Choice<T>(T[] items)
 		{
+			if (items.Length <= 0 || items == null)
+			{
+				throw new ArgumentNullException(nameof(items), $"The items is empty of null.");
+			}
+
 			if (items.Length > int.MaxValue)
 			{
 				throw new ArgumentOutOfRangeException(nameof(items), $"The items length or size can't be greater than int.MaxValue or { int.MaxValue }.");
@@ -108,6 +113,11 @@ namespace Litdex.Security.RNG
 		/// <inheritdoc/>
 		public virtual T[] Choice<T>(T[] items, int select)
 		{
+			if (items.Length <= 0 || items == null)
+			{
+				throw new ArgumentNullException(nameof(items), $"The items is empty of null.");
+			}
+
 			if (select < 0)
 			{
 				throw new ArgumentOutOfRangeException(nameof(select), $"The number of elements to be retrieved is negative or less than 1.");

--- a/Security/RNG/Random.cs
+++ b/Security/RNG/Random.cs
@@ -184,11 +184,7 @@ namespace Litdex.Security.RNG
 			while (selected.Count < select)
 			{
 				var index = this.NextInt(0, (uint)(items.Length - 1));
-
-				if (selected.Contains(items[index]) == false)
-				{
-					selected.Add(items[index]);
-				}
+				selected.Add(items[index]);
 			}
 
 			return selected.ToArray();

--- a/Security/RNG/Random.cs
+++ b/Security/RNG/Random.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace Litdex.Security.RNG
 {
@@ -250,6 +251,12 @@ namespace Litdex.Security.RNG
 		}
 
 		/// <inheritdoc/>
+		public virtual Task<T[]> SampleAsync<T>(T[] items, int k)
+		{
+			return Task.FromResult(this.Sample(items, k));
+		}
+
+		/// <inheritdoc/>
 		public virtual void Shuffle<T>(T[] items)
 		{
 			if (items.Length <= 0 || items == null)
@@ -266,6 +273,14 @@ namespace Litdex.Security.RNG
 				items[i] = items[index];
 				items[index] = temp;
 			}
+		}
+
+		/// <inheritdoc/>
+		public Task ShuffleAsync<T>(T[] items)
+		{
+			this.Shuffle(items);
+
+			return Task.CompletedTask;
 		}
 
 		#endregion Sequence

--- a/Security/RNG/Random32.cs
+++ b/Security/RNG/Random32.cs
@@ -1,4 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
+
+#if NET5_0
+using System.Buffers.Binary;
+#endif
 
 namespace Litdex.Security.RNG
 {
@@ -39,19 +44,56 @@ namespace Litdex.Security.RNG
 				throw new ArgumentOutOfRangeException(nameof(length), $"The requested output size can't lower than 1.");
 			}
 
-			uint sample = 0;
-			var data = new byte[length];
+#if NET5_0
+			var chunk = new Span<byte>(new byte[4]);
+			List<byte> output = new List<byte>(length);
 
-			for (var i = 0; i < length; i++)
+			while (length >= 4)
 			{
-				if (i % 4 == 0)
-				{
-					sample = this.Next();
-				}
-				data[i] = (byte)sample;
-				sample >>= 8;
+				BinaryPrimitives.WriteUInt32LittleEndian(chunk, this.Next());
+				output.AddRange(chunk.ToArray());
+				length -= 4;
 			}
-			return data;
+
+			if (data != 0)
+			{
+				BinaryPrimitives.WriteUInt32LittleEndian(chunk, this.Next());
+				output.AddRange(chunk.Slice(0, length).ToArray());
+			}
+
+			return output.ToArray();
+#else
+			uint sample = 0;
+			var chunk = new byte[4];
+			List<byte> output = new List<byte>(length);
+
+			while (length >= 4)
+			{
+				sample = this.Next();
+
+				chunk[0] = (byte)sample;
+				chunk[1] = (byte)(sample >> 8);
+				chunk[2] = (byte)(sample >> 16);
+				chunk[3] = (byte)(sample >> 24);
+				
+				output.AddRange(chunk);
+				
+				length -= 4;
+			}
+
+			if (length != 0)
+			{
+				sample = this.Next();
+
+				for (int i = 0; i < length; i++)
+				{
+					output.Add((byte)sample);
+					sample >>= 8;
+				}
+			}
+
+			return output.ToArray();
+#endif
 		}
 
 		/// <inheritdoc/>

--- a/Security/RNG/Random32.cs
+++ b/Security/RNG/Random32.cs
@@ -1,10 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 
-#if NET5_0
-using System.Buffers.Binary;
-#endif
-
 namespace Litdex.Security.RNG
 {
 	/// <summary>
@@ -45,19 +41,19 @@ namespace Litdex.Security.RNG
 			}
 
 #if NET5_0
-			var chunk = new Span<byte>(new byte[4]);
+			var chunk = new System.Span<byte>(new byte[4]);
 			List<byte> output = new List<byte>(length);
 
 			while (length >= 4)
 			{
-				BinaryPrimitives.WriteUInt32LittleEndian(chunk, this.Next());
+				System.Buffers.BinaryPrimitives.WriteUInt32LittleEndian(chunk, this.Next());
 				output.AddRange(chunk.ToArray());
 				length -= 4;
 			}
 
 			if (data != 0)
 			{
-				BinaryPrimitives.WriteUInt32LittleEndian(chunk, this.Next());
+				System.Buffers.BinaryPrimitives.WriteUInt32LittleEndian(chunk, this.Next());
 				output.AddRange(chunk.Slice(0, length).ToArray());
 			}
 

--- a/Security/RNG/Random32.cs
+++ b/Security/RNG/Random32.cs
@@ -63,7 +63,9 @@ namespace Litdex.Security.RNG
 		/// <inheritdoc/>
 		public override ulong NextLong()
 		{
-			return BitConverter.ToUInt64(this.NextBytes(8), 0);
+			ulong high = this.NextInt();
+			ulong low = this.NextInt();
+			return high << 32 | low;
 		}
 
 		#endregion Public Method

--- a/Security/RNG/Random64.cs
+++ b/Security/RNG/Random64.cs
@@ -98,7 +98,7 @@ namespace Litdex.Security.RNG
 		/// <inheritdoc/>
 		public override uint NextInt()
 		{
-			return (uint)this.Next();
+			return unchecked((uint)this.Next());
 		}
 
 		/// <inheritdoc/>

--- a/Security/RNG/Random64.cs
+++ b/Security/RNG/Random64.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace Litdex.Security.RNG
 {
@@ -38,20 +39,60 @@ namespace Litdex.Security.RNG
 			{
 				throw new ArgumentOutOfRangeException(nameof(length), $"The requested output size can't lower than 1.");
 			}
+#if NET5_0
+			var chunk = new System.Span<byte>(new byte[8]);
+			List<byte> output = new List<byte>(length);
 
-			ulong sample = 0;
-			var data = new byte[length];
-
-			for (var i = 0; i < length; i++)
+			while (length >= 8)
 			{
-				if (i % 8 == 0)
-				{
-					sample = this.Next();
-				}
-				data[i] = (byte)sample;
-				sample >>= 8;
+				System.Buffers.Binary.BinaryPrimitives.WriteUInt64LittleEndian(chunk, this.rng.NextLong());
+				output.AddRange(chunk.ToArray());
+				length -= 8;
 			}
-			return data;
+
+			if (length != 0)
+			{
+				System.Buffers.Binary.BinaryPrimitives.WriteUInt32LittleEndian(chunk, this.rng.NextInt());
+				output.AddRange(chunk.Slice(0, length).ToArray());
+			}
+
+			return output.ToArray();
+#else
+			ulong sample = 0;
+			var chunk = new byte[8];
+			List<byte> output = new List<byte>(length);
+
+			while (length >= 8)
+			{
+				sample = this.Next();
+
+				chunk[0] = (byte)sample;
+				chunk[1] = (byte)(sample >> 8);
+				chunk[2] = (byte)(sample >> 16);
+				chunk[3] = (byte)(sample >> 24);
+				chunk[4] = (byte)(sample >> 32);
+				chunk[5] = (byte)(sample >> 40);
+				chunk[6] = (byte)(sample >> 48);
+				chunk[7] = (byte)(sample >> 56);
+
+				output.AddRange(chunk);
+
+				length -= 8;
+			}
+
+			if (length != 0)
+			{
+				sample = this.Next();
+
+				for (int i = 0; i < length; i++)
+				{
+					output.Add((byte)sample);
+					sample >>= 8;
+				}
+			}
+
+			return output.ToArray();
+#endif
 		}
 
 		/// <inheritdoc/>


### PR DESCRIPTION
- [x] add missing namespace for Romu random
- [x] new version of Squares #24 
- [x] improve performance to generate ulong from 32 bit generator
- [x] improve generating byte[] in random32

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.18363.1198 (1909/November2018Update/19H2)
AMD FX-8800P Radeon R7, 12 Compute Cores 4C+8G, 1 CPU, 4 logical and 4 physical cores
.NET Core SDK=5.0.100
  [Host]    : .NET Core 5.0.0 (CoreCLR 5.0.20.51904, CoreFX 5.0.20.51904), X64 RyuJIT
  MediumRun : .NET Core 5.0.0 (CoreCLR 5.0.20.51904, CoreFX 5.0.20.51904), X64 RyuJIT

Job=MediumRun  IterationCount=15  LaunchCount=2  
WarmupCount=10  

```
|                       Method | length |        Mean |      Error |     StdDev |         Min |         Max | Ratio | Rank |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------------------- |------- |------------:|-----------:|-----------:|------------:|------------:|------:|-----:|-------:|------:|------:|----------:|
| Version 2.2.0 .netstandard2.0 |   1024 |    30.73 ns |   0.781 ns |   1.145 ns |    29.40 ns |    33.71 ns | 0.006 |    1 | 0.1224 |     - |     - |      64 B |
| Version 2.2.0 .net 5 |   1024 |    38.81 ns |   3.309 ns |   4.953 ns |    31.51 ns |    49.36 ns | 0.007 |    2 | 0.1224 |     - |     - |      64 B |
| Version 2.1.0 |   1024 | 5,198.62 ns | 117.143 ns | 175.334 ns | 4,982.05 ns | 5,551.33 ns | 1.000 |    3 | 1.9989 |     - |     - |    1048 B |

- [x] improve generating byte[] in random64

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.18363.1198 (1909/November2018Update/19H2)
AMD FX-8800P Radeon R7, 12 Compute Cores 4C+8G, 1 CPU, 4 logical and 4 physical cores
.NET Core SDK=5.0.100
  [Host]    : .NET Core 5.0.0 (CoreCLR 5.0.20.51904, CoreFX 5.0.20.51904), X64 RyuJIT
  MediumRun : .NET Core 5.0.0 (CoreCLR 5.0.20.51904, CoreFX 5.0.20.51904), X64 RyuJIT

Job=MediumRun  IterationCount=15  LaunchCount=2  
WarmupCount=10  

```
|                    Method | length |        Mean |      Error |     StdDev |         Min |         Max | Ratio | Rank |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------------- |------- |------------:|-----------:|-----------:|------------:|------------:|------:|-----:|-------:|------:|------:|----------:|
| &#39;Version 2.2.0 .netstd 2&#39; |   1024 |    29.93 ns |   0.964 ns |   1.414 ns |    27.39 ns |    32.94 ns | 0.008 |    1 | 0.1224 |     - |     - |      64 B |
|    &#39;Version 2.2.0 .net 5&#39; |   1024 |    35.88 ns |   2.214 ns |   3.175 ns |    31.39 ns |    40.07 ns | 0.010 |    2 | 0.1224 |     - |     - |      64 B |
|           &#39;Version 2.1.0&#39; |   1024 | 3,585.27 ns | 100.532 ns | 150.472 ns | 3,264.37 ns | 3,901.70 ns | 1.000 |    3 | 2.0027 |     - |     - |    1048 B |

- [x] New method for IRNG, `Shuffle`.
- [x] Fix issue #26 
- [x] Add new Method, `Sample`.
- [x] Add async method for `Sample` and `Shuffle`, used for large arrays.